### PR TITLE
Add Jest setup and chart tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# WEB-HABITYA
+
+This project contains the static front end for the Habitya website.
+
+## Running tests
+
+Install dependencies and run the test suite with:
+
+```bash
+npm install
+npm test
+```
+
+The tests use Jest with the jsdom environment.

--- a/js/script.js
+++ b/js/script.js
@@ -185,3 +185,8 @@ function submitInvoice() {
   closeModal();
   alert('Factura subida correctamente');
 }
+
+// Export functions for testing in Node
+if (typeof module !== 'undefined') {
+  module.exports = { initProgressChart, initIncomeChart };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "web-habitya",
+  "version": "1.0.0",
+  "description": "Habitya web",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "jsdom": "^22.0.0"
+  }
+}

--- a/tests/chart.test.js
+++ b/tests/chart.test.js
@@ -1,0 +1,35 @@
+const { initProgressChart, initIncomeChart } = require('../js/script');
+
+describe('chart initialization', () => {
+  beforeEach(() => {
+    global.Chart = jest.fn();
+  });
+
+  test('initProgressChart uses correct data', () => {
+    document.body.innerHTML = `
+      <span id="paidAmount"></span>
+      <span id="remainingAmount"></span>
+      <canvas id="progressChart"></canvas>
+    `;
+
+    initProgressChart();
+
+    expect(global.Chart).toHaveBeenCalled();
+    const args = global.Chart.mock.calls[0][1];
+    expect(args.data.datasets[0].data).toEqual([3000, 6000]);
+  });
+
+  test('initIncomeChart uses correct data', () => {
+    document.body.innerHTML = `
+      <span id="totalIncome"></span>
+      <span id="pendingIncome"></span>
+      <canvas id="incomeChart"></canvas>
+    `;
+
+    initIncomeChart();
+
+    expect(global.Chart).toHaveBeenCalled();
+    const args = global.Chart.mock.calls[0][1];
+    expect(args.data.datasets[0].data).toEqual([9000, 1500]);
+  });
+});


### PR DESCRIPTION
## Summary
- add initial README with test instructions
- export chart initialization functions
- configure Jest and jsdom
- add tests for progress and income charts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d0938aebc832cb04e05166ce7bc05