### PR TITLE
Add Chart.js and invoice modal

### DIFF
--- a/inquilinos.html
+++ b/inquilinos.html
@@ -42,6 +42,7 @@
     </div>
   </main>
 
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="js/script.js"></script>
 </body>
 </html>

--- a/propietarios.html
+++ b/propietarios.html
@@ -32,20 +32,33 @@
       <button onclick="loginOwner(event)">Entrar</button>
     </div>
 
-    <div id="dashboard-owner" class="hidden mt-8">
-      <h2>Resumen de Ingresos</h2>
-      <canvas id="incomeChart"></canvas>
-      <p>Totales: <span id="totalIncome"></span></p>
-      <p>Pendiente: <span id="pendingIncome"></span></p>
-      <div class="flex gap-4 mt-4">
-        <button onclick="verContratos()">Contratos</button>
-        <button onclick="openModal()">Subir Factura</button>
-        <button onclick="manageProperties()">Propiedades</button>
-        <button onclick="scheduleMaintenance()">Mantenimiento</button>
+      <div id="dashboard-owner" class="hidden mt-8">
+        <h2>Resumen de Ingresos</h2>
+        <canvas id="incomeChart"></canvas>
+        <p>Totales: <span id="totalIncome"></span></p>
+        <p>Pendiente: <span id="pendingIncome"></span></p>
+        <div class="flex gap-4 mt-4">
+          <button onclick="verContratos()">Contratos</button>
+          <button onclick="openModal()">Subir Factura</button>
+          <button onclick="manageProperties()">Propiedades</button>
+          <button onclick="scheduleMaintenance()">Mantenimiento</button>
+        </div>
       </div>
-    </div>
+
+      <div id="invoice-modal" class="modal hidden">
+        <div class="modal-content">
+          <h3>Nueva Factura</h3>
+          <input id="modal-amount" type="number" placeholder="Cantidad (€)">
+          <textarea id="modal-desc" placeholder="Descripción"></textarea>
+          <div class="flex justify-end gap-4">
+            <button onclick="closeModal()">Cancelar</button>
+            <button onclick="submitInvoice()">Enviar</button>
+          </div>
+        </div>
+      </div>
   </main>
 
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="js/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- include Chart.js CDN before app script on tenant and owner pages
- add missing modal markup for submitting invoices on the owner page

## Testing
- `npm test` *(fails: Missing script and network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685e4d0be8c0832caed1012b19cd9e2a