### PR TITLE
Add bottom information sections

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -43,6 +43,28 @@
     </div>
   </main>
 
+  <!-- Sección Informativa estilo Airbnb -->
+  <section class="bottom-links container mt-16">
+    <div class="grid-3 gap-6">
+      <div>
+        <h3>Contacto</h3>
+        <p><a href="contacto.html">Ponte en contacto</a> para cualquier consulta.</p>
+      </div>
+      <div>
+        <h3>Alquila con Habitya</h3>
+        <p>Descubre cómo <a href="propietarios.html">publicar tu vivienda</a> y obtener ingresos.</p>
+      </div>
+      <div>
+        <h3>Habitya Living</h3>
+        <p>Conoce más sobre nuestro proyecto y equipo.</p>
+      </div>
+    </div>
+  </section>
+
+  <footer class="footer container mt-16">
+    <p>&copy; 2025 Habitya Living. Todos los derechos reservados.</p>
+  </footer>
+
 </body>
 </html>
 

--- a/css/estilos.css
+++ b/css/estilos.css
@@ -391,3 +391,17 @@ body {
   body { padding-top: 70px; }
 }
 
+/* Sección inferior de enlaces estilo Airbnb */
+.bottom-links {
+  background: #fff;
+  padding: 2rem 0;
+}
+.bottom-links h3 {
+  margin-bottom: 0.5rem;
+  font-size: 1.25rem;
+}
+.bottom-links a {
+  color: var(--brand-secondary);
+  text-decoration: underline;
+}
+

--- a/index.html
+++ b/index.html
@@ -178,6 +178,24 @@
     </div>
   </section>
 
+  <!-- Sección Informativa estilo Airbnb -->
+  <section class="bottom-links container mt-16" data-aos="fade-up">
+    <div class="grid-3 gap-6">
+      <div>
+        <h3>Contacto</h3>
+        <p><a href="contacto.html">Ponte en contacto</a> para cualquier consulta.</p>
+      </div>
+      <div>
+        <h3>Alquila con Habitya</h3>
+        <p>Descubre cómo <a href="propietarios.html">publicar tu vivienda</a> y obtener ingresos.</p>
+      </div>
+      <div>
+        <h3>Habitya Living</h3>
+        <p>Conoce más sobre nuestro proyecto y equipo.</p>
+      </div>
+    </div>
+  </section>
+
   <!-- Footer -->
   <footer class="footer container mt-16" data-aos="fade-up">
     <p>&copy; 2025 Habitya Living. Todos los derechos reservados.</p>

--- a/inquilinos.html
+++ b/inquilinos.html
@@ -42,6 +42,24 @@
     </div>
   </main>
 
+  <!-- Sección Informativa estilo Airbnb -->
+  <section class="bottom-links container mt-16">
+    <div class="grid-3 gap-6">
+      <div>
+        <h3>Contacto</h3>
+        <p><a href="contacto.html">Ponte en contacto</a> para cualquier consulta.</p>
+      </div>
+      <div>
+        <h3>Alquila con Habitya</h3>
+        <p>Descubre cómo <a href="propietarios.html">publicar tu vivienda</a> y obtener ingresos.</p>
+      </div>
+      <div>
+        <h3>Habitya Living</h3>
+        <p>Conoce más sobre nuestro proyecto y equipo.</p>
+      </div>
+    </div>
+  </section>
+
   <script src="js/script.js"></script>
 </body>
 </html>

--- a/pisos.html
+++ b/pisos.html
@@ -77,6 +77,24 @@
     </div>
   </main>
 
+  <!-- Sección Informativa estilo Airbnb -->
+  <section class="bottom-links container mt-16">
+    <div class="grid-3 gap-6">
+      <div>
+        <h3>Contacto</h3>
+        <p><a href="contacto.html">Ponte en contacto</a> para cualquier consulta.</p>
+      </div>
+      <div>
+        <h3>Alquila con Habitya</h3>
+        <p>Descubre cómo <a href="propietarios.html">publicar tu vivienda</a> y obtener ingresos.</p>
+      </div>
+      <div>
+        <h3>Habitya Living</h3>
+        <p>Conoce más sobre nuestro proyecto y equipo.</p>
+      </div>
+    </div>
+  </section>
+
   <!-- FOOTER -->
   <footer class="footer container mt-16">
     <p>&copy; 2025 Habitya Living. Todos los derechos reservados.</p>

--- a/propietarios.html
+++ b/propietarios.html
@@ -46,6 +46,24 @@
     </div>
   </main>
 
+  <!-- Sección Informativa estilo Airbnb -->
+  <section class="bottom-links container mt-16">
+    <div class="grid-3 gap-6">
+      <div>
+        <h3>Contacto</h3>
+        <p><a href="contacto.html">Ponte en contacto</a> para cualquier consulta.</p>
+      </div>
+      <div>
+        <h3>Alquila con Habitya</h3>
+        <p>Descubre cómo <a href="propietarios.html">publicar tu vivienda</a> y obtener ingresos.</p>
+      </div>
+      <div>
+        <h3>Habitya Living</h3>
+        <p>Conoce más sobre nuestro proyecto y equipo.</p>
+      </div>
+    </div>
+  </section>
+
   <script src="js/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a new bottom-links section with contact, hosting info and about us on all pages
- include matching styles

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685e4c1d6ee4832c9aceac49fbbff5fc